### PR TITLE
ci: Harden Dependabot auto-merge (skip majors, least privilege, native auto-merge)

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,72 +1,38 @@
 name: Auto-merge Dependabot PRs
 
-on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+# Auto-merge Dependabot's minor and patch updates once required checks pass.
+# Runs on `pull_request`; the job-level `permissions:` block elevates the
+# GITHUB_TOKEN for Dependabot's own PRs. Major updates are left for manual
+# review, matching the "Separate major updates for careful review" intent in
+# .github/dependabot.yml.
+on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+# Least privilege by default: no token scopes at the workflow level. Only the
+# job below elevates, and only for Dependabot's own PRs, so a write-scoped token
+# is never exposed to other contributors' pull requests.
+permissions: {}
 
 jobs:
-  auto-merge:
+  dependabot-auto-merge:
     runs-on: ubuntu-latest
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
-
+    # Gate the whole (write-scoped) job on the actor, not just the merge step.
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Get PR details
-        id: pr-details
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { data: pullRequests } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.payload.workflow_run.head_sha,
-            });
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
 
-            if (pullRequests.length === 0) {
-              console.log('No PR found for this commit');
-              return null;
-            }
-
-            const pr = pullRequests[0];
-            console.log(`Found PR #${pr.number} by ${pr.user.login}`);
-
-            return {
-              number: pr.number,
-              user: pr.user.login,
-              mergeable_state: pr.mergeable_state
-            };
-
-      - name: Auto-merge Dependabot PRs
-        if: fromJSON(steps.pr-details.outputs.result).user == 'dependabot[bot]'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const prNumber = ${{ fromJSON(steps.pr-details.outputs.result).number }};
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-
-            console.log(`PR #${prNumber} mergeable_state: ${pr.mergeable_state}`);
-
-            if (pr.mergeable_state === 'clean') {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                merge_method: 'squash',
-                commit_title: pr.title,
-                commit_message: `${pr.title}\n\n${pr.body || ''}`
-              });
-              console.log(`Successfully merged PR #${prNumber}`);
-            } else {
-              console.log(`PR #${prNumber} not ready for merge. State: ${pr.mergeable_state}`);
-            }
+      - name: Enable auto-merge for minor and patch updates
+        # Skip semver-major bumps; they need a human. Reads the update type from
+        # the Dependabot metadata rather than parsing the PR title.
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # `--auto` asks GitHub to merge only after required status checks pass,
+          # so there is no need to poll the PR's mergeable state ourselves.
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
Reworks the Dependabot auto-merge workflow to the `dependabot/fetch-metadata` + native `gh pr merge --auto` pattern, addressing review feedback that also applies to the copies of this file in our other repos.

## Fixes
- **Skip semver-major** — only minor/patch auto-merge (via `fetch-metadata`), matching the `dependabot.yml` "Separate major updates for careful review" intent.
- **No transient `mergeable_state`** — `gh pr merge --auto` merges only after required checks pass.
- **Correct PR** — operates on `github.event.pull_request` directly instead of `listPullRequestsAssociatedWithCommit[0]` (which can return multiple/closed PRs).
- **Least privilege** — `permissions: {}` at the workflow level, `contents`/`pull-requests: write` only on the job, and the whole job gated on `github.actor == 'dependabot[bot]'`.

## Type of Change
- [x] 🔧 CI / Security hardening

## Requirement
Needs repo setting **Allow auto-merge** enabled (already enabled on this repo).