### PR TITLE
ci: Publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,13 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Lets the runner mint the OIDC token npm exchanges for publish rights.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       
       - uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          # Node 24 ships npm 11.x; trusted publishing needs npm >= 11.5.1.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # npm's trusted-publishing guide: never cache in release builds.
+          package-manager-cache: false
       
       - run: npm ci
       
@@ -26,9 +31,13 @@ jobs:
       
       - run: npm test
       
+      # Recorded so a publish failure can be diagnosed without a re-run.
+      - name: Report npm version
+        run: npm --version
+
+      # No NODE_AUTH_TOKEN: auth is the OIDC token above, exchanged against the
+      # trusted publisher registered for this package on npmjs.com.
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
       - name: Create summary
         if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **npm publishing moved to trusted publishing (OIDC)** ([#68](https://github.com/SilverAssist/performance-toolkit/issues/68)). `publish.yml` no longer reads an `NPM_TOKEN` secret: it requests `id-token: write` and npm exchanges that OIDC token for publish rights against the trusted publisher registered for this package. Long-lived tokens are on a deprecation clock — from January 2027 2FA-bypass granular tokens lose direct publishing entirely. The publish job moves to Node 24 because trusted publishing requires npm >= 11.5.1 and Node 24 ships npm 11.x natively, where Node 22 would need a global npm upgrade step whose effect is not verifiable from the log. Since the repo and package are both public, publishing over OIDC also attests provenance automatically.
+
 ## [0.4.0] - 2026-02-07
 
 ### Changed


### PR DESCRIPTION
## Summary

Replaces the `NPM_TOKEN` secret with [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers). Closes #68.

## ⚠️ Do not merge until the trusted publisher exists

If this merges before npmjs.com knows about the publisher, the next release fails.

npmjs.com → `@silverassist/performance-toolkit` → Settings → Trusted Publisher → GitHub Actions:

| Field | Value |
| --- | --- |
| Organization | `SilverAssist` |
| Repository | `performance-toolkit` |
| Workflow filename | `publish.yml` — **filename only, not a path** |
| Environment | **leave empty** — setting it makes npm require a matching `environment:` in the job, which this workflow does not declare |
| Allowed actions | `npm publish` |

That form has a separate **Set up connection** button from **Update Package Settings**. On `agents-toolkit` the publisher silently was not saved the first time and cost a failed release, so verify afterwards:

```bash
npm trust list @silverassist/performance-toolkit
```

## Changes

```diff
     permissions:
       contents: read
+      id-token: write

-          node-version: '20.x'
+          node-version: '24'
+          package-manager-cache: false

+      - name: Report npm version
+        run: npm --version
+
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

**Node 24 is required, not cosmetic.** Trusted publishing needs npm ≥ 11.5.1 and Node ≥ 22.14.0. Node 24 ships npm 11.17.0 natively; Node 22 ships npm 10.x and would need a global `npm install -g npm@latest` step whose effect on the subsequent `npm publish` is not verifiable from the log — `agents-toolkit` tried that first and removed it.

`package-manager-cache: false` follows npm's guide (never cache in release builds). `npm --version` makes a future failure diagnosable without a re-run.

## Why now

The token approach is on a deprecation clock. Per [GitHub's 2026-07-08 changelog](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/), from **early August 2026** 2FA-bypass granular tokens stop bypassing 2FA for sensitive operations, and from **January 2027** they lose direct publishing entirely.

It has already cost releases: on `agents-toolkit` the token failed twice in a row — `E404` (expired; npm returns 404 rather than 403 on auth failures so it does not leak package existence) then `EOTP` (a classic *Publish* token, which unlike an *Automation* token does not bypass 2FA).

## Verification

Verified locally on **Node 24.19.0 / npm 11.17.0** — the exact npm the runner reported: `npm ci`, lint/typecheck, build and tests all pass in this repo.

Proven end-to-end on `@silverassist/agents-toolkit@2.8.1`, which published over OIDC with no token and attested provenance:

```
dist.attestations → predicateType: 'https://slsa.dev/provenance/v1'
```

## After merge

`NPM_TOKEN` stays in repo secrets so a rollback is a one-line revert. Once a release has gone out over OIDC, delete the secret and switch *Publishing access* to "Require two-factor authentication and disallow bypass 2fa tokens".

Reference implementation: SilverAssist/agents-toolkit#66, #67, #69.
