### PR TITLE
ci: Test on the Node version the release actually builds on

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,8 +11,14 @@ on:
 
 jobs:
   quality:
-    name: Code Quality
+    # publish.yml builds and releases on Node 24; testing only on 20 shipped an
+    # artifact built on a version CI never exercised.
+    name: Code Quality (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20.x', '24.x']
 
     steps:
       - name: Checkout code
@@ -21,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20.x"
+          node-version: ${{ matrix.node }}
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Found while auditing consistency across the five `@silverassist` packages after SilverAssist/recaptcha#55, where a dead CI trigger let a release-breaking dependency bump reach the default branch unnoticed.

`publish.yml` builds and publishes on **Node 24** (required by trusted publishing, which needs npm ≥ 11.5.1). CI only ever ran **Node 20**. Every release therefore shipped an artifact built on a Node version CI had never exercised.

## Change

The quality job now runs a matrix:

```yaml
strategy:
  fail-fast: false
  matrix:
    node: ['20.x', '24.x']
```

Node 20 coverage is **kept, not replaced** — dropping it would stop verifying the version consumers may still be on.



## Audit context

The same audit checked all five repos on: CI trigger branch vs actual default branch, CI/publish Node parity, action versions, `dependabot.yml` presence, and `engines` declarations.

| | agents-toolkit | consent-banner | icons | perf-toolkit | recaptcha |
| --- | --- | --- | --- | --- | --- |
| CI covers publish's Node | ✅ 22+24 matrix | ❌ → fixed here | ❌ → fixed here | ❌ → fixed here | ✅ 24 |
| `dependabot.yml` | ✅ | ❌ → fixed here | ✅ | ✅ | ✅ |
| Actions version | v7 | v4 in ci.yml → fixed here | v7 | v7 | v7 |
| `engines` | `>=22.0.0` | none | none | `>=18.0.0` | none |

Two findings are **deliberately left out** of this PR because they need a decision rather than a fix:

- **`engines` is inconsistent** — `agents-toolkit` declares `>=22.0.0`, `performance-toolkit` `>=18.0.0` (Node 18 is EOL, and CI never verified it), and three packages declare nothing at all, so npm cannot warn anyone installing on an unsupported runtime. Adding or raising a floor changes what consumers are allowed to install, so it is a semver-adjacent call.
- **No repo has branch protection** on its default branch. Combined with the recaptcha finding — where CI had never run once — nothing structurally prevents an unvalidated change from landing.
