### PR TITLE
chore: Standardize Dependabot auto-merge and engines

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,10 +1,29 @@
 name: Auto-merge Dependabot PRs
 
-# Auto-merge Dependabot's minor and patch updates once required checks pass.
-# Runs on `pull_request`; the job-level `permissions:` block elevates the
-# GITHUB_TOKEN for Dependabot's own PRs. Major updates are left for manual
-# review, matching the "Separate major updates for careful review" intent in
-# .github/dependabot.yml.
+# Auto-merge Dependabot's minor and patch updates once required checks pass AND
+# the bumped versions have aged past a release-age cooldown. Runs on
+# `pull_request`; the job-level `permissions:` block elevates the GITHUB_TOKEN
+# for Dependabot's own PRs. Major updates are left for manual review, matching
+# the "Separate major updates for careful review" intent in .github/dependabot.yml.
+#
+# Release-age cooldown (supply-chain guard): a freshly-published version is the
+# window in which a compromised or broken release is most likely still live —
+# `npm ci` runs a dependency's install scripts on the runner, so a bad release
+# is a risk the test suite would not catch. The cooldown holds auto-merge until
+# every bumped version in the PR has been public for a minimum number of days
+# (patch: 3, minor: 7). A held PR stays open for a human to review and merge —
+# nothing is rejected, only kept from merging itself too soon.
+#
+# The cooldown is scoped to the npm ecosystem, since it reads publish times from
+# the npm registry. This repo also updates `github-actions`; those deps are not
+# npm packages (the registry returns 404), so they skip the cooldown and merge
+# on the required checks as before.
+#
+# This workflow is only half the gate. The other half is branch protection on
+# `main`, which lists the `Code Quality (Node 20.x)`, `Code Quality (Node 24.x)` context(s)
+# as required — without that, `gh pr merge --auto` has nothing to wait for and
+# Dependabot's PRs merge without CI having passed. If auto-merge ever starts
+# landing red commits, check the protection rule before this file.
 on: pull_request
 
 # Least privilege by default: no token scopes at the workflow level. Only the
@@ -20,19 +39,135 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v3
 
-      - name: Enable auto-merge for minor and patch updates
-        # Skip semver-major bumps; they need a human. Reads the update type from
-        # the Dependabot metadata rather than parsing the PR title.
+      - name: Enforce release-age cooldown
+        id: cooldown
+        # Majors are never auto-merged, so their age is moot — skip the check and
+        # leave `merge` unset, which the merge step already excludes on its own.
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        uses: actions/github-script@v9
+        env:
+          UPDATED: ${{ steps.metadata.outputs.updated-dependencies-json }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        with:
+          script: |
+            const DAY = 86_400_000;
+            const HOLD_MARKER = "<!-- dependabot-cooldown-hold -->";
+            const updated = JSON.parse(process.env.UPDATED || "[]");
+            // A grouped PR carries several deps; fetch-metadata reports the
+            // highest bump in the group as update-type, so a group holding any
+            // minor lands on the 7-day threshold — the conservative choice.
+            const isPatch =
+              process.env.UPDATE_TYPE === "version-update:semver-patch";
+            const minDays = isPatch ? 3 : 7;
+            const now = Date.now();
+
+            const checked = [];
+            const skipped = [];
+            const young = [];
+            for (const dep of updated) {
+              const name = dep.dependencyName;
+              const version = dep.newVersion;
+              if (!name || !version) {
+                // No metadata to verify → fail closed rather than wave it through.
+                young.push(`${name ?? "unknown"} (missing version metadata)`);
+                continue;
+              }
+              let publishedAt;
+              try {
+                const res = await fetch(
+                  `https://registry.npmjs.org/${name.replace("/", "%2F")}`,
+                  { headers: { "user-agent": "dependabot-cooldown" } },
+                );
+                if (res.status === 404) {
+                  // Not on npm — this repo also runs the `github-actions`
+                  // ecosystem, whose deps (`actions/checkout`, …) are not npm
+                  // packages. The npm cooldown does not apply; let the required
+                  // checks gate it instead of holding it forever.
+                  skipped.push(`${name}@${version} (not an npm package)`);
+                  continue;
+                }
+                if (!res.ok) throw new Error(`registry ${res.status}`);
+                publishedAt = (await res.json()).time?.[version];
+              } catch (err) {
+                // A registry hiccup must not auto-merge an unverified version.
+                young.push(`${name}@${version} (registry lookup failed: ${err.message})`);
+                continue;
+              }
+              if (!publishedAt) {
+                young.push(`${name}@${version} (no publish time on registry)`);
+                continue;
+              }
+              const ageDays = (now - new Date(publishedAt).getTime()) / DAY;
+              checked.push(`${name}@${version}: ${ageDays.toFixed(1)}d`);
+              if (ageDays < minDays) {
+                young.push(`${name}@${version} (${ageDays.toFixed(1)}d < ${minDays}d)`);
+              }
+            }
+
+            core.info(`Release-age cooldown threshold: ${minDays} day(s).`);
+            for (const line of checked) core.info(`  ${line}`);
+            for (const line of skipped) core.info(`  skipped: ${line}`);
+
+            const ok = young.length === 0;
+            core.setOutput("merge", ok ? "true" : "false");
+            if (ok) return;
+
+            core.warning(`Auto-merge held by cooldown: ${young.join("; ")}`);
+
+            // Comment once, not on every rebase-triggered re-run.
+            try {
+              const prNumber = context.payload.pull_request.number;
+              const { data: comments } =
+                await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 100,
+                });
+              if (comments.some((c) => c.body?.includes(HOLD_MARKER))) return;
+              const body = [
+                HOLD_MARKER,
+                `🕒 **Auto-merge held by the release-age cooldown** (minimum ${minDays} day(s)).`,
+                "",
+                "These bumped versions are too new to auto-merge — a guard against freshly-published malicious or broken releases:",
+                "",
+                ...young.map((y) => `- ${y}`),
+                "",
+                "The PR stays open for manual review. It will not merge on its own; re-run this workflow (or merge manually) once the versions have aged.",
+              ].join("\n");
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            } catch (err) {
+              // The comment is courtesy; the gate is `merge=false`. Never let a
+              // comment failure fail the step and imply something merged.
+              core.warning(`Could not post cooldown comment: ${err.message}`);
+            }
+
+      - name: Enable auto-merge for minor and patch updates
+        # Skip semver-major bumps; they need a human. Also require the cooldown to
+        # have cleared every bumped version. Reads the update type from the
+        # Dependabot metadata rather than parsing the PR title.
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-major' &&
+          steps.cooldown.outputs.merge == 'true'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          # `--auto` asks GitHub to merge only after required status checks pass,
-          # so there is no need to poll the PR's mergeable state ourselves.
+          # `--auto` waits only for the checks branch protection marks as
+          # *required*. With none configured it merges as soon as the PR is
+          # mergeable, which is how #24 landed a lockfile that broke `npm ci`
+          # on Node 20 and 22 — the CI matrix had not finished, and nothing was
+          # waiting for it. `main` now requires all nine `check` contexts, so
+          # this line means what it always claimed to.
           gh pr merge --auto --squash "$PR_URL"

--- a/package.json
+++ b/package.json
@@ -177,6 +177,6 @@
     "typescript-eslint": "^8.54.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Standardizes Dependabot auto-merge across the five `@silverassist` packages, and normalizes `engines`. Part of the consistency audit that started with SilverAssist/recaptcha#55, where a dead CI trigger let a release-breaking bump reach the default branch.

## Auto-merge workflow

Three different states existed across the org: `agents-toolkit` and `performance-toolkit` shared one version, `icons` had an older `github-script` variant, and `consent-banner` and `recaptcha` had none at all.

The canonical version turned out **not** to be the one in `agents-toolkit` but the one in `jsdoc-to-tsdoc`, which adds a **release-age cooldown**: a bumped version must have been public for a minimum number of days (patch 3, minor 7) before auto-merge is allowed. `npm ci` runs dependency install scripts on the runner, so a freshly-published compromised or broken release is a risk the test suite would never catch. A held PR stays open for a human — nothing is rejected.

Everything else is preserved: `permissions: {}` at workflow level with the write-scoped job gated on `github.actor == 'dependabot[bot]'`, and semver-majors never auto-merged.

## ⚠️ Branch protection is the other half

The workflow's own header says it plainly:

> This workflow is only half the gate. The other half is branch protection … without that, `gh pr merge --auto` has nothing to wait for and Dependabot's PRs merge without CI having passed.

**No repo in this org had branch protection.** Enabling auto-merge without it would have made Dependabot merge PRs regardless of CI — the exact failure mode of #55. Protection with the CI checks listed as required is being enabled alongside this change.

## `engines`

Was `>=18.0.0`. Node 18 is End-of-Life and CI never tested it, so the claim was unverified. Now `>=20.0.0`, matching what CI actually verifies (a 20.x + 24.x matrix).

## Repo settings

Applied out-of-band via the API on all five repos:

- `delete_branch_on_merge=true` — merged branches now clean themselves up.
- `allow_auto_merge=true` on `consent-banner`, the only one where it was off, which would have made `gh pr merge --auto` fail outright.
