### PR TITLE
chore: Add husky pre-commit and pre-push hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Pre-commit: branch protection + formatting of staged files.
+#
+# Deliberately cheap. A commit is a checkpoint; the full gate runs on pre-push,
+# which is where work becomes visible to other people and to CI.
+#
+# Output goes through `printf`, not `echo`: whether `echo` expands a backslash
+# escape is implementation-defined in POSIX, while `printf` is specified.
+#
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+protected_branches="main master"
+
+for branch in $protected_branches; do
+    if [ "$current_branch" = "$branch" ]; then
+        printf '\n'
+        printf '%b🚫 COMMIT BLOCKED!%b\n' "$RED" "$NC"
+        printf '%b❌ Direct commits to '"'"'%b%s%b'"'"' are not allowed.%b\n' \
+            "$RED" "$YELLOW" "$current_branch" "$RED" "$NC"
+        printf '\n'
+        printf '%b📋 Branch first:%b\n' "$CYAN" "$NC"
+        printf '   %bgit checkout -b feature/short-description%b\n' "$GREEN" "$NC"
+        printf '   %bgit checkout -b fix/short-description%b\n' "$GREEN" "$NC"
+        printf '\n'
+        printf '%b   Everything reaches the default branch through a reviewed pull request.%b\n' \
+            "$CYAN" "$NC"
+        printf '\n'
+        exit 1
+    fi
+done
+
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Pre-push: the full gate.
+#
+# The same checks CI runs, before the push rather than after. The suite takes a
+# couple of seconds here, so there is no reason to defer it to a runner and find
+# out minutes later across two matrix legs.
+#
+# Output goes through `printf`, not `echo`: whether `echo` expands a backslash
+# escape is implementation-defined in POSIX, while `printf` is specified.
+#
+
+CYAN='\033[0;36m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+printf '\n'
+printf '%b🔍 Running the full gate before pushing…%b\n' "$CYAN" "$NC"
+printf '\n'
+
+if ! npm run check; then
+    printf '\n'
+    printf '%b🚫 PUSH BLOCKED — the gate failed.%b\n' "$RED" "$NC"
+    printf '\n'
+    printf '%bFix it, or push once with:%b\n' "$CYAN" "$NC"
+    printf '   %bgit push --no-verify%b\n' "$GREEN" "$NC"
+    printf '\n'
+    exit 1
+fi
+
+printf '\n'
+printf '%b✅ Gate clean — pushing.%b\n' "$GREEN" "$NC"
+printf '\n'

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,9 @@
         "@typescript-eslint/parser": "^8.54.0",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
+        "husky": "^9.1.7",
         "jest": "^30.2.0",
+        "lint-staged": "^17.3.0",
         "prettier": "^3.8.1",
         "ts-jest": "^29.4.6",
         "tsdown": "^0.22.14",
@@ -33,7 +35,7 @@
         "typescript-eslint": "^8.54.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "@lhci/cli": ">=0.12.0",
@@ -6011,6 +6013,22 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8178,6 +8196,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
+      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.5",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/localforage": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
@@ -9838,6 +9893,16 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -10150,6 +10215,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10429,16 +10504,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tsdown/node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -11068,6 +11133,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -132,9 +132,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",
-    "build:watch": "tsup --watch",
+    "build:watch": "tsdown --watch",
     "clean": "rm -rf dist",
-    "dev": "tsup --watch",
+    "dev": "tsdown --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.ts\" \"bin/**/*.js\"",
@@ -143,7 +143,9 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit",
-    "release": "npm run prepublishOnly && npm publish --access public"
+    "release": "npm run prepublishOnly && npm publish --access public",
+    "check": "npm run typecheck && npm run lint && npm run test",
+    "prepare": "husky || true"
   },
   "peerDependencies": {
     "@lhci/cli": ">=0.12.0",
@@ -169,7 +171,9 @@
     "@typescript-eslint/parser": "^8.54.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
+    "husky": "^9.1.7",
     "jest": "^30.2.0",
+    "lint-staged": "^17.3.0",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",
     "tsdown": "^0.22.14",
@@ -178,5 +182,13 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,mjs,cjs,json,md}": [
+      "prettier --write"
+    ],
+    "*.{ts,tsx}": [
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `husky` pre-commit and pre-push hooks, matching the setup already in `agents-toolkit` and `jsdoc-to-tsdoc` — where the pre-push gate has repeatedly caught failures before they reached CI (it blocked a malformed workflow file earlier today).

| Hook | Does | Cost |
| --- | --- | --- |
| `pre-commit` | Blocks direct commits to `main`/`master`, then runs `lint-staged` over staged files only | negligible |
| `pre-push` | Runs the full `check` gate | **2–3s in this repo** |

A new `check` script composes the repo's existing scripts: ``npm run typecheck && npm run lint && npm run test``.

## Why, given branch protection already exists

Branch protection prevents an unvalidated *merge*. These hooks are about **feedback speed**, not control — you learn in 2 seconds locally instead of 40 seconds of CI, and the PR does not collect "fix lint" commits. They can be skipped with `--no-verify`, so they never substitute for CI.

The pre-push gate was measured before being added: at 2–3 seconds it is not worth deferring. Where a suite is slow, this trade-off would go the other way.

## Also in this PR

Scripts left pointing at `tsup` after the tsdown migration are fixed. `dev` (and `build:watch` where present) would have failed with `tsup: command not found`, since that dependency is gone.


