### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-08-21
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silverassist/performance-toolkit",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@silverassist/performance-toolkit",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "PolyForm Noncommercial License 1.0.0",
       "dependencies": {
         "chalk": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silverassist/performance-toolkit",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "PageSpeed Insights and Lighthouse CI integration for performance monitoring across SilverAssist projects",
   "author": "Miguel Colmenares <me@miguelcolmenares.com>",
   "license": "PolyForm Noncommercial License 1.0.0",


### PR DESCRIPTION
## Changes

### Fixed
- **All 8 subpath exports were unresolvable in the published `0.4.0`.** Every subpath's `import.default` pointed at a `.mjs` file the tsup build never produced — `publint` confirmed all 8 missing against the published tarball. The tsdown migration below is what actually builds the files the `exports` map has declared since `0.4.0`.
- **`node10` module resolution failed for every subpath.** Added `typesVersions` mapping each to its `.d.ts`.
- `repository.url` now a full `git+https://` URL.

### Changed
- Replaced tsup with tsdown (unmaintained, unbounded TypeScript peer range).
- Node 22 minimum, matching what CI actually runs.
- npm publishing moved to trusted publishing (OIDC) — no token in the repo.
- Standardized Dependabot auto-merge, added husky hooks.

## Verification

Clean-room (`rm -rf node_modules dist && npm ci`): `check` ✅, `build` ✅, `publint` → **All good!**, `attw` → all 8 entry points 🟢 across node10, node16 (CJS+ESM), bundler.

## After merge

`publish.yml` triggers on `release: [created]` — a bare tag will not fire it.