### PR TITLE
chore: normalize the license field to the SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.0",
   "description": "PageSpeed Insights and Lighthouse CI integration for performance monitoring across SilverAssist projects",
   "author": "Miguel Colmenares <me@miguelcolmenares.com>",
-  "license": "PolyForm Noncommercial License 1.0.0",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",
   "overrides": {
     "cookie": "^0.7.2",


### PR DESCRIPTION
Three spellings existed across the org's npm packages. Only `PolyForm-Noncommercial-1.0.0` is the actual SPDX identifier (confirmed against [spdx.org](https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html)); this repo had `"PolyForm Noncommercial License 1.0.0"` (missing the hyphens). Normalizing to match `recaptcha`, `agents-toolkit`, `next-testing-toolkit`.

Metadata-only, no build/behavior impact — `npm run check` unchanged.